### PR TITLE
Doc CI configuration updates:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.DS_Store
 
 # Vim ignores
 [._]*.s[a-v][a-z]

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ansi-escape-sequences": "^4.0.0",
     "bluebird": "^3.5.1",
     "capitalize": "^1.0.0",
+    "deepmerge": "^2.1.1",
     "fs-extra-promise": "^1.0.1",
     "image-size": "^0.6.3",
     "lodash": "^4.17.10",

--- a/scripts/checks/broken_links.js
+++ b/scripts/checks/broken_links.js
@@ -1,22 +1,45 @@
 #!/usr/bin/env node
 
 // run HTMLProofer, which checks for broken links/images in the HTML
-const ansi  = require('ansi-escape-sequences')
-const color = ansi.style
-const debug = require('../_debug')
-const exec  = require('child_process').execSync
+const ansi    = require('ansi-escape-sequences')
+const color   = ansi.style
+const debug   = require('../_debug')
+const exec    = require('child_process').execSync
+const merge   = require('deepmerge')
+const ovMerge = (destinationArray, sourceArray, options) => sourceArray
 
 var proofed = false
-var results  = []
+var results = []
+var config  = {
+  "broken_links.js": {
+    folder:                 "_book",
+    "disable-external":     true,
+    "allow-hash-href":      true,
+    "check-external-hash":  false,
+    "check-img-http":       false,
+    "empty-alt-ignore":     false
+  }
+}
+
+// setup
+const setup = (myConfig) => {
+  config = merge(config, myConfig, { arrayMerge: ovMerge })
+}
 
 // scan the lines in a file, but we just return the output
-const scan = (lines, docFile, external = false) => {
+const scan = (lines, docFile) => {
   if (proofed) return results
 
-  const command = (external)
-    ? "htmlproofer --allow-hash-href _book"
-    : "htmlproofer --allow-hash-href --disable-external _book"
+  var command = "htmlproofer"
+  const conf = config["broken_links.js"]
+  if (conf["allow-hash-href"])     command += " --allow-hash-href"
+  if (conf["check-external-hash"]) command += " --check-external-hash"
+  if (conf["check-img-http"])      command += " --check-img-http"
+  if (conf["disable-external"])    command += " --disable-external"
+  if (conf["empty-alt-ignore"])    command += " --empty-alt-ignore"
+  command += " " + conf.folder
 
+  debug.out("HTML-Proofer command:", command)
   console.log('')
   // using "inherit" causes HTMLProofer output to be displayed "live"
   // so no need to capture it here.
@@ -43,9 +66,9 @@ const report = (results) => {
 
 // Demonstrate this check during direct execution
 if (require.main === module) {
-  setup()
+  setup({})
   results = scan([])
   report(results)
 }
 
-module.exports = { name: "Broken Links/Images", scan, report }
+module.exports = { name: "Broken Links/Images", scan, report, setup }

--- a/scripts/checks/images.js
+++ b/scripts/checks/images.js
@@ -2,22 +2,16 @@
 
 // check for missed images, or images with incorrect sizes
 const path    = require('path')
+const merge   = require('deepmerge')
+const ovMerge = (destinationArray, sourceArray, options) => sourceArray
 const ansi    = require('ansi-escape-sequences')
 const color   = ansi.style
 const walk    = require('walk-sync')
 const debug   = require('../_debug')
 const sizeOf  = require('image-size')
 
-var images        = {}
-var docPath       = ''
-var unreferenced  = false
-
-// scan doc source tree for images
-const setup = (folder) => {
-  debug.PREFIX = "IMG"
-  debug.out(`Scanning ${folder} for images...`)
-  docPath = folder
-  walk(folder, {
+var config        = {
+  "images.js": {
     directories: false,
     globs: [
       "**/*.gif",
@@ -27,9 +21,24 @@ const setup = (folder) => {
       "**/*.svg"
     ],
     ignore: [ "_book", "_interbit", "node_modules", "vendor" ]
-  }).map((imgFile) => {
+  }
+}
+var images        = {}
+var docPath       = ''
+var unreferenced  = false
+
+// scan doc source tree for images
+const setup = (myConfig) => {
+  config = merge(config, myConfig, { arrayMerge: ovMerge })
+  docPath = config.docPath
+
+  debug.PREFIX = "IMG"
+  debug.out(`Scanning ${docPath} for images...`)
+
+  walk(docPath, config["images.js"]).map((imgFile) => {
     images[imgFile] = false
   })
+
   debug.out(`Scanning complete, found:`)
   Object.keys(images).map((imgFile) => {
     debug.out(`Found: --${imgFile}==`)

--- a/scripts/checks/includes.js
+++ b/scripts/checks/includes.js
@@ -2,22 +2,16 @@
 
 // check for missed includes
 const path    = require('path')
-const ansi    = require('ansi-escape-sequences')
-const color   = ansi.style
+const merge   = require('deepmerge')
+const ovMerge = (destinationArray, sourceArray, options) => sourceArray
 const walk    = require('walk-sync')
 const debug   = require('../_debug')
 const sizeOf  = require('image-size')
+const ansi    = require('ansi-escape-sequences')
+const color   = ansi.style
 
-var includes      = {}
-var docPath       = ''
-var unreferenced  = false
-
-// scan doc source tree for includes
-const setup = (folder) => {
-  debug.PREFIX = "INC"
-  debug.out(`Scanning ${folder} for includes...`)
-  docPath = folder
-  walk(folder, {
+var config        = {
+  "includes.js": {
     directories: false,
     globs: [
       "**/*.css",
@@ -35,9 +29,25 @@ const setup = (folder) => {
       "package.json", "package-lock.json",
       "app.json", "book.json"
     ]
-  }).map((incFile) => {
+  }
+}
+
+var includes      = {}
+var docPath       = ''
+var unreferenced  = false
+
+// scan doc source tree for includes
+const setup = (myConfig) => {
+  config = merge(config, myConfig, { arrayMerge: ovMerge })
+  docPath = config.docPath
+
+  debug.PREFIX = "INC"
+  debug.out(`Scanning ${docPath} for includes...`)
+
+  walk(docPath, config["includes.js"]).map((incFile) => {
     includes[incFile] = false
   })
+
   debug.out(`Scanning complete, found:`)
   Object.keys(includes).map((incFile) => {
     debug.out(`Found: --${incFile}==`)

--- a/scripts/checks/line_length.js
+++ b/scripts/checks/line_length.js
@@ -2,12 +2,25 @@
 
 // check for line length; long lines makes for awkward diffs
 const path    = require('path')
+const merge   = require('deepmerge')
+const ovMerge = (destinationArray, sourceArray, options) => sourceArray
 const ansi    = require('ansi-escape-sequences')
 const color   = ansi.style
 const debug   = require('../_debug')
 const pattern = new RegExp(/(\b\S+\b)\s+(\b\1\b(?!-))/, "g")
 
-const maxLength = 80
+var config = {
+  "line_length.js": {
+    maxLength: 80
+  }
+}
+var maxLength = config["line_length.js"].maxLength
+
+// setup
+const setup = (myConfig) => {
+  config = merge(config, myConfig, { arrayMerge: ovMerge })
+  maxLength = config["line_length.js"].maxLength
+}
 
 // scan the lines in a file
 const scan = (lines) => {
@@ -168,7 +181,7 @@ const report = (results) => {
   })
   if (count) {
     console.log('')
-    console.log("Wrap the identified lines to fit within 80 columns.")
+    console.log(`Wrap the identified lines to fit within ${maxLength} columns.`)
   }
 }
 
@@ -191,4 +204,4 @@ if (require.main === module) {
   report( results )
 }
 
-module.exports = { name: "Line Lengths", scan, report }
+module.exports = { name: "Line Lengths", scan, report, setup }

--- a/scripts/checks/missed_files.js
+++ b/scripts/checks/missed_files.js
@@ -5,19 +5,30 @@ const ansi    = require('ansi-escape-sequences')
 const color   = ansi.style
 const walk    = require('walk-sync')
 const debug   = require('../_debug')
+const merge   = require('deepmerge')
+const ovMerge = (destinationArray, sourceArray, options) => sourceArray
 
+var config = {
+  "missed_files.js": {
+    folder: "_book",
+    walk: {
+      directories: false,
+      globs: [ "**/*.md", "**/*.adoc" ],
+      ignore: [ "node_modules", "vendor" ]
+    }
+  }
+}
 var missed = []
 
 // scan the _book directory for unprocessed files
-const setup = () => {
+const setup = (myConfig) => {
+  config = merge(config, myConfig, { arrayMerge: ovMerge })
+  const conf = config["missed_files.js"]
+
   debug.PREFIX = "MF"
   debug.out(`Scanning '_book' for unprocessed files...`)
-  missed = walk("_book", {
-    directories: false,
-    globs: [ "**/*.md", "**/*.adoc" ],
-    ignore: [ "node_modules", "vendor" ]
-  })
-  debug.out(`Scanning complete, found ${missed}`)
+  missed = walk(conf.folder, conf.walk)
+  debug.out(`Scanning complete, found:`, missed)
 }
 
 // scan the lines in a file

--- a/scripts/doc_checks.js
+++ b/scripts/doc_checks.js
@@ -4,16 +4,135 @@
 // - applies each kind of "check" script to each source file
 // - reports any issues discovered
 
-const fs         = require('fs-extra-promise')
-const path       = require('path')
-const walk       = require('walk-sync')
-const ansi       = require('ansi-escape-sequences')
-const color      = ansi.style
+const fs    = require('fs-extra-promise')
+const path  = require('path')
+const merge = require('deepmerge')
+const ovMerge = (destinationArray, sourceArray, options) => sourceArray
+const walk  = require('walk-sync')
+const ansi  = require('ansi-escape-sequences')
+const color = ansi.style
+const debug = require('./_debug')
+
+// setup to process arguments
+var argv = require('minimist')(process.argv.slice(2))
+
+// handle configuration early, so we can act on it properly.
+var configFile = './doc_ci.json'
+if ('F' in argv) configFile = path.resolve(argv['F'])
+if ('configFile' in argv) configFile = path.resolve(argv['configFile'])
+
+// initial configuration
+var config = {
+  checkPath:        path.join(__dirname, 'checks'),
+  checkToRun:       'ALL',
+  checksToSkip:     {},
+  docPath:          path.join(process.cwd()),
+  debug:            false,
+  walk: {
+    directories: false,
+    globs: [ "**/*.md", "**/*.adoc" ],
+    ignore: [ "_book", "_interbit", "node_modules", "vendor" ]
+  },
+  "broken_links.js": {
+    folder:                 "_book",
+    "disable-external":     false,
+    "allow-hash-href":      true,
+    "check-external-hash":  false,
+    "check-img-http":       false,
+    "empty-alt-ignore":     false
+  },
+  "images.js": {
+    directories: false,
+    globs: [
+      "**/*.gif",
+      "**/*.jpg",
+      "**/*.jpeg",
+      "**/*.png",
+      "**/*.svg"
+    ],
+    ignore: [ "_book", "_interbit", "node_modules", "vendor" ]
+  },
+  "includes.js": {
+    directories: false,
+    globs: [
+      "**/*.css",
+      "**/*.html",
+      "**/*.js",
+      "**/*.json",
+      "**/*.jsx",
+      "**/*.markdown",
+      "apiadoc/**/*.adoc",
+      "apiadoc/**/**/*.adoc"
+    ],
+    ignore: [
+      "_*", "node_modules", "vendor",
+      "index.js", "local.js",
+      "package.json", "package-lock.json",
+      "app.json", "book.json"
+    ]
+  },
+  "line_length.js": {
+    maxLength: 80
+  },
+  "missed_files.js": {
+    folder: "_book",
+    walk: {
+      directories: false,
+      globs: [ "**/*.md", "**/*.adoc" ],
+      ignore: [ "node_modules", "vendor" ]
+    }
+  }
+}
+
+if ('v' in argv) config.debug = true
+if ('verbose' in argv) config.debug = true
+
+// merge in JSON config, if it exists
+if (fs.existsSync(configFile)) {
+  try {
+    const jsonConfig = JSON.parse(fs.readFileSync(configFile))
+    config = merge(config, jsonConfig, { arrayMerge: ovMerge })
+  }
+  catch (err) {
+    console.log("Config load error:", err)
+    process.exit(1)
+  }
+}
+debug.DEBUG = config.debug
+
+// process arguments
+if ('d' in argv) config.docPath = argv['d']
+if ('docPath' in argv) config.docPath = argv['docPath']
+
+if (!fs.existsSync(config.docPath)) {
+  console.log(`${config.docPath} does not exist!`)
+  process.exit(1)
+}
+
+if (!fs.statSync(config.docPath).isDirectory()) {
+  console.log(`${config.docPath} is not a directory!`)
+  process.exit(1)
+}
+
+if ('c' in argv) config.checkToRun = argv['c']
+if ('check' in argv) checkToRun = argv['check']
+
+const addToSkip = (item) => {
+  if (!item.match(/\.js$/)) item += ".js"
+  config.checksToSkip[item] = true
+}
+if ('s' in argv) argv['s'].split(',').map((item) => { addToSkip(item) })
+if ('skip' in argv) argv['skip'].split(',').map((item) => { addToSkip(item) })
+
+debug.out("Initial configuration:", config)
 
 // load doc checks (only those with filenames ending in ".js", to make
 // it easy to disable select checks)
 //
 // each check script exports:
+//-  setup(config, docPath) -> void
+//   executed to accept config, and to prepare for scanning
+//
 // - scan(lines) -> results
 //   processes the passed lines array and returns an array of results
 //
@@ -23,55 +142,12 @@ const color      = ansi.style
 //
 // - report(results) -> void
 //   prints a report for the passed results
-//
-//-  setup(docPath) -> void
-//   Optional export: if exported, executed to prepare for scanning
 const checkPath = path.join(__dirname, 'checks')
 const checks    = {}
 fs.readdirSync(checkPath).sort().map((check) => {
   if (!check.match(/\.js$/)) return
   checks[check] = require(path.join(checkPath, check))
 })
-
-// process arguments
-var argv = require('minimist')(process.argv.slice(2))
-var docPath = path.join(process.cwd())
-if ('d' in argv) docPath = argv['d']
-if ('docPath' in argv) docPath = argv['docPath']
-
-if (!fs.existsSync(docPath)) {
-  console.log(`${docPath} does not exist!`)
-  process.exit(1)
-}
-
-if (!fs.statSync(docPath).isDirectory()) {
-  console.log(`${docPath} is not a directory!`)
-  process.exit(1)
-}
-
-var chk = 'ALL'
-if ('c' in argv) chk = argv['c']
-if ('check' in argv) chk = argv['check']
-
-var find = /\.(md|adoc)/
-if ('f' in argv) find = new RegExp(argv['f'])
-if ('find' in argv) find = new RegExp(argv['find'])
-
-const debug = require('./_debug')
-if ('v' in argv) debug.DEBUG = true
-if ('verbose' in argv) debug.DEBUG = true
-
-var external = false
-if ('x' in argv) external = true
-if ('external' in argv) external = true
-
-var skip = {}
-const addToSkip = (item) => {
-  if (!item.match(/\.js$/)) item += ".js"
-  skip[item] = true
-}
-if ('s' in argv) argv['s'].split(',').map((item) => { addToSkip(item) })
-if ('skip' in argv) argv['skip'].split(',').map((item) => { addToSkip(item) })
 
 // assume success
 var problems = false
@@ -82,20 +158,16 @@ const print = (msg) => { process.stdout.write(msg) }
 print(`${color.bold}Checking doc content...${color.reset}\n`)
 
 // scan the directory tree for doc source files
-const files = walk(docPath, {
-  directories: false,
-  globs: [ "**/*.md", "**/*.adoc" ],
-  ignore: [ "_*", "node_modules", "vendor" ]
-}).sort()
+const files = walk(config.docPath, config.walk).sort()
 
 // run all of the checks
 Object.keys(checks).map((check) => {
-  if (chk != 'ALL') {
-    var re = RegExp(chk + '\(\.js\)\?')
+  if (config.checkToRun != 'ALL') {
+    var re = RegExp(config.checkToRun + '\(\.js\)\?')
     if (!check.match(re)) return
   }
 
-  if (check in skip) {
+  if (check in config.checksToSkip) {
     print(`Skipping ${checks[check].name} check...`)
     return
   }
@@ -106,24 +178,24 @@ Object.keys(checks).map((check) => {
   if (checks[check].setup
     && typeof checks[check].setup === "function") {
     debug.out(`Running setup for ${check}`)
-    checks[check].setup(docPath)
+    checks[check].setup(config)
   }
   else {
     debug.out(`No setup function provided by ${check}; skipping...`)
   }
 
   // process each file
-  files.map((path) => {
+  files.map((filePath) => {
     debug.PREFIX = 'DC'
-    debug.out(`Processing file: ${path}`)
+    debug.out(`Processing file: ${filePath}`)
 
-    var lines = fs.readFileSync(path, { encoding: 'utf8' })
+    var lines = fs.readFileSync(filePath, { encoding: 'utf8' })
       .split(/\r?\n/)
 
     // scan the lines with the current check
-    var result = checks[check].scan(lines, path, external)
+    var result = checks[check].scan(lines, filePath)
     if (result.length) {
-      results[path] = result
+      results[filePath] = result
       problems = true
     }
   })


### PR DESCRIPTION
* Accept config from external file, default `./doc_ci.json`.
* Configure external configuration with `-F` flag.
* Apply comfiguration to all check scripts.
* Re-work spell check script:
  * Allow additional dictionaries via paths in config file.
  * Initialize nspell once per run, instead of once per file,
    resulting in ~100x speedup.
    
For the default configuration structure, refer to doc_checks.js.